### PR TITLE
fix subdirectories problem

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function(options) {
       if(!file.isDirectory())
       {
         rimraf(file.revOrigPath, function(err) {
-          if (err) cb(err);
+          if (err) return cb(err);
           cb(null, file);
         });
       } else {

--- a/index.js
+++ b/index.js
@@ -18,13 +18,15 @@ module.exports = function(options) {
 
     //delete the original file
     var del = function() {
-      remove(file.revOrigPath, function(err) {
-        if (err) {
-          cb(err);
-        } else {
+      if(!file.isDirectory())
+      {
+        rimraf(file.revOrigPath, function(err) {
+          if (err) cb(err);
           cb(null, file);
-        }
-      });
+        });
+      } else {
+        cb(null);
+      }
     };
 
     //don't delete files that haven't been rewritten

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function(options) {
 
     //delete the original file
     var del = function() {
-      if(!file.isDirectory())
+      if(file.revOrigPath)
       {
         rimraf(file.revOrigPath, function(err) {
           if (err) return cb(err);


### PR DESCRIPTION
link with the issue #1  : 

``` javascript
var gulp        = require('gulp'),
    rev         = require('gulp-rev'),
    revDel      = require('gulp-rev-delete-original');

gulp.task('hashres:assets', function () {
    return gulp.src('dist/assets/**/*').pipe(rev())
        .pipe(revDel())
        .pipe(gulp.dest('dist/assets'))
        .pipe(rev.manifest('manifest-assets.json', { merge : true }))
        .pipe(gulp.dest('tmp'));
});
```

The error provides on directory with empty subdirectory.

In my case, I have the directory `dist/assets/flags/4x3/` with files but the parent directory `dist/assets/flags` has no ressources to remove.
