### PR TITLE
add description to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "gulp-rev-delete-original",
   "version": "0.2.2",
+  "description": "Delete the original file rewritten by gulp-rev.",
   "keywords": [
     "gulpplugin",
     "rev",


### PR DESCRIPTION
this info is exposed on yarnpkg.com, npmjs.com and others. If it's not filled in, the first part of the readme is used (which causes duplication)